### PR TITLE
Replace devtools package with remotes

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -47,7 +47,7 @@ The General Social Survey Cumulative Data (1972-2018) and Three Wave Panel Data 
 You can install the beta version of gssr from [GitHub](https://github.com/kjhealy/gssr) with:
 
 ``` r
-devtools::install_github("kjhealy/gssr")
+remotes::install_github("kjhealy/gssr")
 ```
 
 ### Installation using `drat`

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ core R package repository. There are two ways to install it.
 You can install the beta version of gssr from
 [GitHub](https://github.com/kjhealy/gssr) with:
 
-    devtools::install_github("kjhealy/gssr")
+    remotes::install_github("kjhealy/gssr")
 
 ### Installation using `drat`
 


### PR DESCRIPTION
Love your work Professor Healy. It seems like people should use remotes rather than devtools to install the package. Please ignore this PR if I am mistaken.